### PR TITLE
🔄 Add `ws-feature-store/manifest.json` route + seed payload

### DIFF
--- a/.github/workflows/distribute.yaml
+++ b/.github/workflows/distribute.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   resolve:
+    name: 🔍 Resolve targets
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.targets }}
@@ -30,6 +31,7 @@ jobs:
           scripts/distribute.sh "$FILES"
 
   sync:
+    name: 🔄 Sync (${{ matrix.target.repo }})
     needs: resolve
     if: needs.resolve.outputs.matrix != '[]'
     runs-on: ubuntu-latest

--- a/shared/distribution.yaml
+++ b/shared/distribution.yaml
@@ -13,3 +13,7 @@ shared/workspace/dependencies.yaml:
 shared/workspace/extensions.yaml:
   - repo: ws-docs
     path: .vitepress/data/extensions.yaml
+
+shared/ws-feature-store/manifest.json:
+  - repo: ws-docs
+    path: .vitepress/data/fs-manifest.json

--- a/shared/ws-feature-store/manifest.json
+++ b/shared/ws-feature-store/manifest.json
@@ -1,0 +1,4156 @@
+{
+  "built": "2026-05-25T09:18:52Z",
+  "packages": [
+    {
+      "name": "apache2-bin",
+      "version": "2.4.67-1~deb13u2",
+      "architecture": "amd64",
+      "link": "pool/main/a/apache2/apache2-bin_2.4.67-1~deb13u2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "apache2-bin",
+      "version": "2.4.67-1~deb13u2",
+      "architecture": "arm64",
+      "link": "pool/main/a/apache2/apache2-bin_2.4.67-1~deb13u2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "aspnetcore-runtime-9.0",
+      "version": "9.0.16-1",
+      "architecture": "amd64",
+      "link": "pool/main/a/aspnetcore-runtime-9.0/aspnetcore-runtime-9.0_9.0.16-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "aspnetcore-targeting-pack-9.0",
+      "version": "9.0.16-1",
+      "architecture": "amd64",
+      "link": "pool/main/a/aspnetcore-targeting-pack-9.0/aspnetcore-targeting-pack-9.0_9.0.16-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "binutils",
+      "version": "2.44-3",
+      "architecture": "amd64",
+      "link": "pool/main/b/binutils/binutils_2.44-3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "binutils",
+      "version": "2.44-3",
+      "architecture": "arm64",
+      "link": "pool/main/b/binutils/binutils_2.44-3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "binutils-common",
+      "version": "2.44-3",
+      "architecture": "amd64",
+      "link": "pool/main/b/binutils/binutils-common_2.44-3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "binutils-common",
+      "version": "2.44-3",
+      "architecture": "arm64",
+      "link": "pool/main/b/binutils/binutils-common_2.44-3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "binutils-x86-64-linux-gnu",
+      "version": "2.44-3",
+      "architecture": "amd64",
+      "link": "pool/main/b/binutils/binutils-x86-64-linux-gnu_2.44-3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "binutils-x86-64-linux-gnu",
+      "version": "2.44-3",
+      "architecture": "arm64",
+      "link": "pool/main/b/binutils/binutils-x86-64-linux-gnu_2.44-3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "build-essential",
+      "version": "12.12",
+      "architecture": "amd64",
+      "link": "pool/main/b/build-essential/build-essential_12.12_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "build-essential",
+      "version": "12.12",
+      "architecture": "arm64",
+      "link": "pool/main/b/build-essential/build-essential_12.12_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "bun",
+      "version": "1.3.9",
+      "architecture": "amd64",
+      "link": "artifacts/bun/amd64.zip",
+      "type": "artifact"
+    },
+    {
+      "name": "bun",
+      "version": "1.3.9",
+      "architecture": "arm64",
+      "link": "artifacts/bun/arm64.zip",
+      "type": "artifact"
+    },
+    {
+      "name": "bzip2",
+      "version": "1.0.8-6",
+      "architecture": "amd64",
+      "link": "pool/main/b/bzip2/bzip2_1.0.8-6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "bzip2",
+      "version": "1.0.8-6",
+      "architecture": "arm64",
+      "link": "pool/main/b/bzip2/bzip2_1.0.8-6_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "ca-certificates",
+      "version": "20250419",
+      "architecture": "all",
+      "link": "pool/main/c/ca-certificates/ca-certificates_20250419_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "clang",
+      "version": "1:19.0-63",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-defaults/clang_19.0-63_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "clang",
+      "version": "1:19.0-63",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-defaults/clang_19.0-63_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "clang-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-toolchain-19/clang-19_19.1.7-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "clang-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-toolchain-19/clang-19_19.1.7-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "clang-format",
+      "version": "1:19.0-63",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-defaults/clang-format_19.0-63_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "clang-format",
+      "version": "1:19.0-63",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-defaults/clang-format_19.0-63_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "clang-format-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-toolchain-19/clang-format-19_19.1.7-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "clang-format-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-toolchain-19/clang-format-19_19.1.7-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "clang-tidy",
+      "version": "1:19.0-63",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-defaults/clang-tidy_19.0-63_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "clang-tidy",
+      "version": "1:19.0-63",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-defaults/clang-tidy_19.0-63_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "clang-tidy-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-toolchain-19/clang-tidy-19_19.1.7-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "clang-tidy-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-toolchain-19/clang-tidy-19_19.1.7-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "clang-tools-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-toolchain-19/clang-tools-19_19.1.7-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "clang-tools-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-toolchain-19/clang-tools-19_19.1.7-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cloudflared",
+      "version": "2026.5.0",
+      "architecture": "amd64",
+      "link": "pool/main/c/cloudflared/cloudflared_2026.5.0_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cloudflared",
+      "version": "2026.5.0",
+      "architecture": "arm64",
+      "link": "pool/main/c/cloudflared/cloudflared_2026.5.0_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cmake",
+      "version": "3.31.6-2",
+      "architecture": "amd64",
+      "link": "pool/main/c/cmake/cmake_3.31.6-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cmake",
+      "version": "3.31.6-2",
+      "architecture": "arm64",
+      "link": "pool/main/c/cmake/cmake_3.31.6-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cmake-data",
+      "version": "3.31.6-2",
+      "architecture": "all",
+      "link": "pool/main/c/cmake/cmake-data_3.31.6-2_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "composer",
+      "version": null,
+      "architecture": null,
+      "link": "artifacts/composer/composer",
+      "type": "artifact"
+    },
+    {
+      "name": "cpp",
+      "version": "4:14.2.0-1",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-defaults/cpp_14.2.0-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cpp",
+      "version": "4:14.2.0-1",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-defaults/cpp_14.2.0-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cpp-13",
+      "version": "13.3.0-16",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-13/cpp-13_13.3.0-16_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cpp-13",
+      "version": "13.3.0-16",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-13/cpp-13_13.3.0-16_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cpp-13-x86-64-linux-gnu",
+      "version": "13.3.0-16",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-13/cpp-13-x86-64-linux-gnu_13.3.0-16_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cpp-13-x86-64-linux-gnu",
+      "version": "13.3.0-16cross1",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-13-cross/cpp-13-x86-64-linux-gnu_13.3.0-16cross1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cpp-14",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/cpp-14_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cpp-14",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/cpp-14_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cpp-14-x86-64-linux-gnu",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/cpp-14-x86-64-linux-gnu_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cpp-14-x86-64-linux-gnu",
+      "version": "14.2.0-19cross1",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14-cross/cpp-14-x86-64-linux-gnu_14.2.0-19cross1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cpp-x86-64-linux-gnu",
+      "version": "4:14.2.0-1",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-defaults/cpp-x86-64-linux-gnu_14.2.0-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cpp-x86-64-linux-gnu",
+      "version": "4:14.2.0-1",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-defaults/cpp-x86-64-linux-gnu_14.2.0-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "cr",
+      "version": "1.8.1",
+      "architecture": "amd64",
+      "link": "artifacts/cr/amd64.tar.gz",
+      "type": "artifact"
+    },
+    {
+      "name": "cr",
+      "version": "1.8.1",
+      "architecture": "arm64",
+      "link": "artifacts/cr/arm64.tar.gz",
+      "type": "artifact"
+    },
+    {
+      "name": "debconf",
+      "version": "1.5.91",
+      "architecture": "all",
+      "link": "pool/main/d/debconf/debconf_1.5.91_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "distro-info-data",
+      "version": "0.66+deb13u2",
+      "architecture": "all",
+      "link": "pool/main/d/distro-info-data/distro-info-data_0.66+deb13u2_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "dotnet-apphost-pack-9.0",
+      "version": "9.0.16-1",
+      "architecture": "amd64",
+      "link": "pool/main/d/dotnet-apphost-pack-9.0/dotnet-apphost-pack-9.0_9.0.16-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "dotnet-host",
+      "version": "10.0.8",
+      "architecture": "amd64",
+      "link": "pool/main/d/dotnet-host/dotnet-host_10.0.8_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "dotnet-host",
+      "version": "10.0.8",
+      "architecture": "arm64",
+      "link": "pool/main/d/dotnet-host/dotnet-host_10.0.8_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "dotnet-hostfxr-9.0",
+      "version": "9.0.16-1",
+      "architecture": "amd64",
+      "link": "pool/main/d/dotnet-hostfxr-9.0/dotnet-hostfxr-9.0_9.0.16-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "dotnet-runtime-9.0",
+      "version": "9.0.16-1",
+      "architecture": "amd64",
+      "link": "pool/main/d/dotnet-runtime-9.0/dotnet-runtime-9.0_9.0.16-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "dotnet-runtime-deps-9.0",
+      "version": "9.0.16-1",
+      "architecture": "amd64",
+      "link": "pool/main/d/dotnet-runtime-deps-9.0/dotnet-runtime-deps-9.0_9.0.16-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "dotnet-sdk-9.0",
+      "version": "9.0.314-1",
+      "architecture": "amd64",
+      "link": "pool/main/d/dotnet-sdk-9.0/dotnet-sdk-9.0_9.0.314-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "dotnet-targeting-pack-9.0",
+      "version": "9.0.16-1",
+      "architecture": "amd64",
+      "link": "pool/main/d/dotnet-targeting-pack-9.0/dotnet-targeting-pack-9.0_9.0.16-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "dpkg",
+      "version": "1.22.22",
+      "architecture": "amd64",
+      "link": "pool/main/d/dpkg/dpkg_1.22.22_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "dpkg",
+      "version": "1.22.22",
+      "architecture": "arm64",
+      "link": "pool/main/d/dpkg/dpkg_1.22.22_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "dpkg-dev",
+      "version": "1.22.22",
+      "architecture": "all",
+      "link": "pool/main/d/dpkg/dpkg-dev_1.22.22_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "fontconfig-config",
+      "version": "2.15.0-2.3",
+      "architecture": "amd64",
+      "link": "pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "fontconfig-config",
+      "version": "2.15.0-2.3",
+      "architecture": "arm64",
+      "link": "pool/main/f/fontconfig/fontconfig-config_2.15.0-2.3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "fonts-dejavu-core",
+      "version": "2.37-8",
+      "architecture": "all",
+      "link": "pool/main/f/fonts-dejavu/fonts-dejavu-core_2.37-8_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "fonts-dejavu-mono",
+      "version": "2.37-8",
+      "architecture": "all",
+      "link": "pool/main/f/fonts-dejavu/fonts-dejavu-mono_2.37-8_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "g++",
+      "version": "4:14.2.0-1",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-defaults/g++_14.2.0-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "g++",
+      "version": "4:14.2.0-1",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-defaults/g++_14.2.0-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "g++-13",
+      "version": "13.3.0-16",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-13/g++-13_13.3.0-16_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "g++-13",
+      "version": "13.3.0-16",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-13/g++-13_13.3.0-16_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "g++-13-x86-64-linux-gnu",
+      "version": "13.3.0-16",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-13/g++-13-x86-64-linux-gnu_13.3.0-16_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "g++-13-x86-64-linux-gnu",
+      "version": "13.3.0-16cross1",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-13-cross/g++-13-x86-64-linux-gnu_13.3.0-16cross1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "g++-14",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/g++-14_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "g++-14",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/g++-14_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "g++-14-x86-64-linux-gnu",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/g++-14-x86-64-linux-gnu_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "g++-14-x86-64-linux-gnu",
+      "version": "14.2.0-19cross1",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14-cross/g++-14-x86-64-linux-gnu_14.2.0-19cross1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "g++-x86-64-linux-gnu",
+      "version": "4:14.2.0-1",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-defaults/g++-x86-64-linux-gnu_14.2.0-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "g++-x86-64-linux-gnu",
+      "version": "4:14.2.0-1",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-defaults/g++-x86-64-linux-gnu_14.2.0-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc",
+      "version": "4:14.2.0-1",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-defaults/gcc_14.2.0-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc",
+      "version": "4:14.2.0-1",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-defaults/gcc_14.2.0-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc-13",
+      "version": "13.3.0-16",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-13/gcc-13_13.3.0-16_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc-13",
+      "version": "13.3.0-16",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-13/gcc-13_13.3.0-16_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc-13-base",
+      "version": "13.3.0-16",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-13/gcc-13-base_13.3.0-16_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc-13-base",
+      "version": "13.3.0-16",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-13/gcc-13-base_13.3.0-16_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc-13-x86-64-linux-gnu",
+      "version": "13.3.0-16",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-13/gcc-13-x86-64-linux-gnu_13.3.0-16_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc-13-x86-64-linux-gnu",
+      "version": "13.3.0-16cross1",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-13-cross/gcc-13-x86-64-linux-gnu_13.3.0-16cross1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc-14",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/gcc-14_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc-14",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/gcc-14_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc-14-base",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/gcc-14-base_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc-14-base",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/gcc-14-base_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc-14-x86-64-linux-gnu",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/gcc-14-x86-64-linux-gnu_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc-14-x86-64-linux-gnu",
+      "version": "14.2.0-19cross1",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14-cross/gcc-14-x86-64-linux-gnu_14.2.0-19cross1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc-x86-64-linux-gnu",
+      "version": "4:14.2.0-1",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-defaults/gcc-x86-64-linux-gnu_14.2.0-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gcc-x86-64-linux-gnu",
+      "version": "4:14.2.0-1",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-defaults/gcc-x86-64-linux-gnu_14.2.0-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gdb",
+      "version": "16.3-1",
+      "architecture": "amd64",
+      "link": "pool/main/g/gdb/gdb_16.3-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gdb",
+      "version": "16.3-1",
+      "architecture": "arm64",
+      "link": "pool/main/g/gdb/gdb_16.3-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gdbserver",
+      "version": "16.3-1",
+      "architecture": "amd64",
+      "link": "pool/main/g/gdb/gdbserver_16.3-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gdbserver",
+      "version": "16.3-1",
+      "architecture": "arm64",
+      "link": "pool/main/g/gdb/gdbserver_16.3-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gh",
+      "version": "2.92.0",
+      "architecture": "amd64",
+      "link": "pool/main/g/gh/gh_2.92.0_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "gh",
+      "version": "2.92.0",
+      "architecture": "arm64",
+      "link": "pool/main/g/gh/gh_2.92.0_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "git",
+      "version": "1:2.47.3-0+deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/g/git/git_2.47.3-0+deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "git",
+      "version": "1:2.47.3-0+deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/g/git/git_2.47.3-0+deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "git-man",
+      "version": "1:2.47.3-0+deb13u1",
+      "architecture": "all",
+      "link": "pool/main/g/git/git-man_2.47.3-0+deb13u1_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "glab",
+      "version": "1.86.0",
+      "architecture": "amd64",
+      "link": "artifacts/glab/amd64.tar.gz",
+      "type": "artifact"
+    },
+    {
+      "name": "glab",
+      "version": "1.86.0",
+      "architecture": "arm64",
+      "link": "artifacts/glab/arm64.tar.gz",
+      "type": "artifact"
+    },
+    {
+      "name": "google-cloud-cli",
+      "version": "569.0.0-0",
+      "architecture": "amd64",
+      "link": "pool/main/g/google-cloud-cli/google-cloud-cli_569.0.0-0_amd64_ac60c09d238acc2eaf7b968c6f52fb79.deb",
+      "type": "apt"
+    },
+    {
+      "name": "google-cloud-cli",
+      "version": "569.0.0-0",
+      "architecture": "arm64",
+      "link": "pool/main/g/google-cloud-cli/google-cloud-cli_569.0.0-0_arm64_877a5d7b84e6e2de1c520cd5fff590be.deb",
+      "type": "apt"
+    },
+    {
+      "name": "helm-diff",
+      "version": "3.15.0",
+      "architecture": "amd64",
+      "link": "artifacts/helm-diff/amd64.tgz",
+      "type": "artifact"
+    },
+    {
+      "name": "helm-diff",
+      "version": "3.15.0",
+      "architecture": "arm64",
+      "link": "artifacts/helm-diff/arm64.tgz",
+      "type": "artifact"
+    },
+    {
+      "name": "helm-unittest",
+      "version": "1.0.3",
+      "architecture": "amd64",
+      "link": "artifacts/helm-unittest/amd64.tgz",
+      "type": "artifact"
+    },
+    {
+      "name": "helm-unittest",
+      "version": "1.0.3",
+      "architecture": "arm64",
+      "link": "artifacts/helm-unittest/arm64.tgz",
+      "type": "artifact"
+    },
+    {
+      "name": "init-system-helpers",
+      "version": "1.69~deb13u1",
+      "architecture": "all",
+      "link": "pool/main/i/init-system-helpers/init-system-helpers_1.69~deb13u1_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "jfrog-cli-v2-jf",
+      "version": "2.104.1",
+      "architecture": "amd64",
+      "link": "pool/main/j/jfrog-cli-v2-jf/jfrog-cli-2.104.1.x86_64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libabsl20240722",
+      "version": "20240722.0-4",
+      "architecture": "amd64",
+      "link": "pool/main/a/abseil/libabsl20240722_20240722.0-4_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libabsl20240722",
+      "version": "20240722.0-4",
+      "architecture": "arm64",
+      "link": "pool/main/a/abseil/libabsl20240722_20240722.0-4_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libacl1",
+      "version": "2.3.2-2+b1",
+      "architecture": "amd64",
+      "link": "pool/main/a/acl/libacl1_2.3.2-2+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libacl1",
+      "version": "2.3.2-2+b1",
+      "architecture": "arm64",
+      "link": "pool/main/a/acl/libacl1_2.3.2-2+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libaom3",
+      "version": "3.12.1-1",
+      "architecture": "amd64",
+      "link": "pool/main/a/aom/libaom3_3.12.1-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libaom3",
+      "version": "3.12.1-1",
+      "architecture": "arm64",
+      "link": "pool/main/a/aom/libaom3_3.12.1-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libapache2-mod-php8.5",
+      "version": "8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6",
+      "architecture": "amd64",
+      "link": "pool/main/p/php8.5/libapache2-mod-php8.5_8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libapr1t64",
+      "version": "1.7.5-1",
+      "architecture": "amd64",
+      "link": "pool/main/a/apr/libapr1t64_1.7.5-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libapr1t64",
+      "version": "1.7.5-1",
+      "architecture": "arm64",
+      "link": "pool/main/a/apr/libapr1t64_1.7.5-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libaprutil1-dbd-sqlite3",
+      "version": "1.6.3-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/a/apr-util/libaprutil1-dbd-sqlite3_1.6.3-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libaprutil1-dbd-sqlite3",
+      "version": "1.6.3-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/a/apr-util/libaprutil1-dbd-sqlite3_1.6.3-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libaprutil1-ldap",
+      "version": "1.6.3-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/a/apr-util/libaprutil1-ldap_1.6.3-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libaprutil1-ldap",
+      "version": "1.6.3-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/a/apr-util/libaprutil1-ldap_1.6.3-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libaprutil1t64",
+      "version": "1.6.3-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/a/apr-util/libaprutil1t64_1.6.3-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libaprutil1t64",
+      "version": "1.6.3-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/a/apr-util/libaprutil1t64_1.6.3-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libapt-pkg7.0",
+      "version": "3.0.3",
+      "architecture": "amd64",
+      "link": "pool/main/a/apt/libapt-pkg7.0_3.0.3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libapt-pkg7.0",
+      "version": "3.0.3",
+      "architecture": "arm64",
+      "link": "pool/main/a/apt/libapt-pkg7.0_3.0.3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libarchive13t64",
+      "version": "3.7.4-4+deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/liba/libarchive/libarchive13t64_3.7.4-4+deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libarchive13t64",
+      "version": "3.7.4-4+deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/liba/libarchive/libarchive13t64_3.7.4-4+deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libargon2-1",
+      "version": "0~20190702+dfsg-4+b2",
+      "architecture": "amd64",
+      "link": "pool/main/a/argon2/libargon2-1_0~20190702+dfsg-4+b2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libargon2-1",
+      "version": "0~20190702+dfsg-4+b2",
+      "architecture": "arm64",
+      "link": "pool/main/a/argon2/libargon2-1_0~20190702+dfsg-4+b2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libasan8",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/libasan8_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libasan8",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/libasan8_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libatomic1",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/libatomic1_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libatomic1",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/libatomic1_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libavif16",
+      "version": "1.2.1-1.2",
+      "architecture": "amd64",
+      "link": "pool/main/liba/libavif/libavif16_1.2.1-1.2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libavif16",
+      "version": "1.2.1-1.2",
+      "architecture": "arm64",
+      "link": "pool/main/liba/libavif/libavif16_1.2.1-1.2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libbabeltrace1",
+      "version": "1.5.11-4+b2",
+      "architecture": "amd64",
+      "link": "pool/main/b/babeltrace/libbabeltrace1_1.5.11-4+b2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libbabeltrace1",
+      "version": "1.5.11-4+b2",
+      "architecture": "arm64",
+      "link": "pool/main/b/babeltrace/libbabeltrace1_1.5.11-4+b2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libbcg729-0",
+      "version": "1.1.1-3",
+      "architecture": "amd64",
+      "link": "pool/main/b/bcg729/libbcg729-0_1.1.1-3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libbcg729-0",
+      "version": "1.1.1-3",
+      "architecture": "arm64",
+      "link": "pool/main/b/bcg729/libbcg729-0_1.1.1-3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libbinutils",
+      "version": "2.44-3",
+      "architecture": "amd64",
+      "link": "pool/main/b/binutils/libbinutils_2.44-3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libbinutils",
+      "version": "2.44-3",
+      "architecture": "arm64",
+      "link": "pool/main/b/binutils/libbinutils_2.44-3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libblkid1",
+      "version": "2.41-5",
+      "architecture": "amd64",
+      "link": "pool/main/u/util-linux/libblkid1_2.41-5_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libblkid1",
+      "version": "2.41-5",
+      "architecture": "arm64",
+      "link": "pool/main/u/util-linux/libblkid1_2.41-5_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libbrotli1",
+      "version": "1.1.0-2+b7",
+      "architecture": "amd64",
+      "link": "pool/main/b/brotli/libbrotli1_1.1.0-2+b7_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libbrotli1",
+      "version": "1.1.0-2+b7",
+      "architecture": "arm64",
+      "link": "pool/main/b/brotli/libbrotli1_1.1.0-2+b7_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libbsd0",
+      "version": "0.12.2-2",
+      "architecture": "amd64",
+      "link": "pool/main/libb/libbsd/libbsd0_0.12.2-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libbsd0",
+      "version": "0.12.2-2",
+      "architecture": "arm64",
+      "link": "pool/main/libb/libbsd/libbsd0_0.12.2-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libbz2-1.0",
+      "version": "1.0.8-6",
+      "architecture": "amd64",
+      "link": "pool/main/b/bzip2/libbz2-1.0_1.0.8-6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libbz2-1.0",
+      "version": "1.0.8-6",
+      "architecture": "arm64",
+      "link": "pool/main/b/bzip2/libbz2-1.0_1.0.8-6_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libc-dev-bin",
+      "version": "2.41-12+deb13u3",
+      "architecture": "amd64",
+      "link": "pool/main/g/glibc/libc-dev-bin_2.41-12+deb13u3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libc-dev-bin",
+      "version": "2.41-12+deb13u3",
+      "architecture": "arm64",
+      "link": "pool/main/g/glibc/libc-dev-bin_2.41-12+deb13u3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libc6",
+      "version": "2.41-12+deb13u3",
+      "architecture": "amd64",
+      "link": "pool/main/g/glibc/libc6_2.41-12+deb13u3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libc6",
+      "version": "2.41-12+deb13u3",
+      "architecture": "arm64",
+      "link": "pool/main/g/glibc/libc6_2.41-12+deb13u3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libc6-dev",
+      "version": "2.41-12+deb13u3",
+      "architecture": "amd64",
+      "link": "pool/main/g/glibc/libc6-dev_2.41-12+deb13u3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libc6-dev",
+      "version": "2.41-12+deb13u3",
+      "architecture": "arm64",
+      "link": "pool/main/g/glibc/libc6-dev_2.41-12+deb13u3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcap2",
+      "version": "1:2.75-10+deb13u1+b1",
+      "architecture": "amd64",
+      "link": "pool/main/libc/libcap2/libcap2_2.75-10+deb13u1+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcap2",
+      "version": "1:2.75-10+deb13u1+b1",
+      "architecture": "arm64",
+      "link": "pool/main/libc/libcap2/libcap2_2.75-10+deb13u1+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcap2-bin",
+      "version": "1:2.75-10+deb13u1+b1",
+      "architecture": "amd64",
+      "link": "pool/main/libc/libcap2/libcap2-bin_2.75-10+deb13u1+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcap2-bin",
+      "version": "1:2.75-10+deb13u1+b1",
+      "architecture": "arm64",
+      "link": "pool/main/libc/libcap2/libcap2-bin_2.75-10+deb13u1+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcares2",
+      "version": "1.34.5-1+deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/c/c-ares/libcares2_1.34.5-1+deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcares2",
+      "version": "1.34.5-1+deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/c/c-ares/libcares2_1.34.5-1+deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcc1-0",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/libcc1-0_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcc1-0",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/libcc1-0_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libclang-common-19-dev",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-toolchain-19/libclang-common-19-dev_19.1.7-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libclang-common-19-dev",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-toolchain-19/libclang-common-19-dev_19.1.7-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libclang-cpp19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-toolchain-19/libclang-cpp19_19.1.7-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libclang-cpp19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-toolchain-19/libclang-cpp19_19.1.7-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libclang1-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-toolchain-19/libclang1-19_19.1.7-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libclang1-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-toolchain-19/libclang1-19_19.1.7-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcom-err2",
+      "version": "1.47.2-3+b11",
+      "architecture": "amd64",
+      "link": "pool/main/e/e2fsprogs/libcom-err2_1.47.2-3+b11_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcom-err2",
+      "version": "1.47.2-3+b11",
+      "architecture": "arm64",
+      "link": "pool/main/e/e2fsprogs/libcom-err2_1.47.2-3+b11_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcrypt-dev",
+      "version": "1:4.4.38-1",
+      "architecture": "amd64",
+      "link": "pool/main/libx/libxcrypt/libcrypt-dev_4.4.38-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcrypt-dev",
+      "version": "1:4.4.38-1",
+      "architecture": "arm64",
+      "link": "pool/main/libx/libxcrypt/libcrypt-dev_4.4.38-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcrypt1",
+      "version": "1:4.4.38-1",
+      "architecture": "amd64",
+      "link": "pool/main/libx/libxcrypt/libcrypt1_4.4.38-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcrypt1",
+      "version": "1:4.4.38-1",
+      "architecture": "arm64",
+      "link": "pool/main/libx/libxcrypt/libcrypt1_4.4.38-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libctf-nobfd0",
+      "version": "2.44-3",
+      "architecture": "amd64",
+      "link": "pool/main/b/binutils/libctf-nobfd0_2.44-3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libctf-nobfd0",
+      "version": "2.44-3",
+      "architecture": "arm64",
+      "link": "pool/main/b/binutils/libctf-nobfd0_2.44-3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libctf0",
+      "version": "2.44-3",
+      "architecture": "amd64",
+      "link": "pool/main/b/binutils/libctf0_2.44-3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libctf0",
+      "version": "2.44-3",
+      "architecture": "arm64",
+      "link": "pool/main/b/binutils/libctf0_2.44-3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcurl3t64-gnutls",
+      "version": "8.14.1-2+deb13u3",
+      "architecture": "amd64",
+      "link": "pool/main/c/curl/libcurl3t64-gnutls_8.14.1-2+deb13u3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcurl3t64-gnutls",
+      "version": "8.14.1-2+deb13u3",
+      "architecture": "arm64",
+      "link": "pool/main/c/curl/libcurl3t64-gnutls_8.14.1-2+deb13u3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcurl4t64",
+      "version": "8.14.1-2+deb13u3",
+      "architecture": "amd64",
+      "link": "pool/main/c/curl/libcurl4t64_8.14.1-2+deb13u3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libcurl4t64",
+      "version": "8.14.1-2+deb13u3",
+      "architecture": "arm64",
+      "link": "pool/main/c/curl/libcurl4t64_8.14.1-2+deb13u3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libdav1d7",
+      "version": "1.5.1-1",
+      "architecture": "amd64",
+      "link": "pool/main/d/dav1d/libdav1d7_1.5.1-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libdav1d7",
+      "version": "1.5.1-1",
+      "architecture": "arm64",
+      "link": "pool/main/d/dav1d/libdav1d7_1.5.1-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libdb5.3t64",
+      "version": "5.3.28+dfsg2-9",
+      "architecture": "amd64",
+      "link": "pool/main/d/db5.3/libdb5.3t64_5.3.28+dfsg2-9_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libdb5.3t64",
+      "version": "5.3.28+dfsg2-9",
+      "architecture": "arm64",
+      "link": "pool/main/d/db5.3/libdb5.3t64_5.3.28+dfsg2-9_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libdbus-1-3",
+      "version": "1.16.2-2",
+      "architecture": "amd64",
+      "link": "pool/main/d/dbus/libdbus-1-3_1.16.2-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libdbus-1-3",
+      "version": "1.16.2-2",
+      "architecture": "arm64",
+      "link": "pool/main/d/dbus/libdbus-1-3_1.16.2-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libde265-0",
+      "version": "1.0.15-1+b3",
+      "architecture": "amd64",
+      "link": "pool/main/libd/libde265/libde265-0_1.0.15-1+b3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libde265-0",
+      "version": "1.0.15-1+b3",
+      "architecture": "arm64",
+      "link": "pool/main/libd/libde265/libde265-0_1.0.15-1+b3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libdebuginfod-common",
+      "version": "0.192-4",
+      "architecture": "all",
+      "link": "pool/main/e/elfutils/libdebuginfod-common_0.192-4_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libdebuginfod1t64",
+      "version": "0.192-4",
+      "architecture": "amd64",
+      "link": "pool/main/e/elfutils/libdebuginfod1t64_0.192-4_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libdebuginfod1t64",
+      "version": "0.192-4",
+      "architecture": "arm64",
+      "link": "pool/main/e/elfutils/libdebuginfod1t64_0.192-4_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libdeflate0",
+      "version": "1.23-2",
+      "architecture": "amd64",
+      "link": "pool/main/libd/libdeflate/libdeflate0_1.23-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libdeflate0",
+      "version": "1.23-2",
+      "architecture": "arm64",
+      "link": "pool/main/libd/libdeflate/libdeflate0_1.23-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libdpkg-perl",
+      "version": "1.22.22",
+      "architecture": "all",
+      "link": "pool/main/d/dpkg/libdpkg-perl_1.22.22_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libdw1t64",
+      "version": "0.192-4",
+      "architecture": "amd64",
+      "link": "pool/main/e/elfutils/libdw1t64_0.192-4_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libdw1t64",
+      "version": "0.192-4",
+      "architecture": "arm64",
+      "link": "pool/main/e/elfutils/libdw1t64_0.192-4_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libedit2",
+      "version": "3.1-20250104-1",
+      "architecture": "amd64",
+      "link": "pool/main/libe/libedit/libedit2_3.1-20250104-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libedit2",
+      "version": "3.1-20250104-1",
+      "architecture": "arm64",
+      "link": "pool/main/libe/libedit/libedit2_3.1-20250104-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libelf1t64",
+      "version": "0.192-4",
+      "architecture": "amd64",
+      "link": "pool/main/e/elfutils/libelf1t64_0.192-4_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libelf1t64",
+      "version": "0.192-4",
+      "architecture": "arm64",
+      "link": "pool/main/e/elfutils/libelf1t64_0.192-4_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "liberror-perl",
+      "version": "0.17030-1",
+      "architecture": "all",
+      "link": "pool/main/libe/liberror-perl/liberror-perl_0.17030-1_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libexpat1",
+      "version": "2.7.1-2",
+      "architecture": "amd64",
+      "link": "pool/main/e/expat/libexpat1_2.7.1-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libexpat1",
+      "version": "2.7.1-2",
+      "architecture": "arm64",
+      "link": "pool/main/e/expat/libexpat1_2.7.1-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libexpat1-dev",
+      "version": "2.7.1-2",
+      "architecture": "amd64",
+      "link": "pool/main/e/expat/libexpat1-dev_2.7.1-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libexpat1-dev",
+      "version": "2.7.1-2",
+      "architecture": "arm64",
+      "link": "pool/main/e/expat/libexpat1-dev_2.7.1-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libffi8",
+      "version": "3.4.8-2",
+      "architecture": "amd64",
+      "link": "pool/main/libf/libffi/libffi8_3.4.8-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libffi8",
+      "version": "3.4.8-2",
+      "architecture": "arm64",
+      "link": "pool/main/libf/libffi/libffi8_3.4.8-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libfontconfig1",
+      "version": "2.15.0-2.3",
+      "architecture": "amd64",
+      "link": "pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libfontconfig1",
+      "version": "2.15.0-2.3",
+      "architecture": "arm64",
+      "link": "pool/main/f/fontconfig/libfontconfig1_2.15.0-2.3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libfreetype6",
+      "version": "2.13.3+dfsg-1+deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/f/freetype/libfreetype6_2.13.3+dfsg-1+deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libfreetype6",
+      "version": "2.13.3+dfsg-1+deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/f/freetype/libfreetype6_2.13.3+dfsg-1+deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgav1-1",
+      "version": "0.19.0-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/libg/libgav1/libgav1-1_0.19.0-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgav1-1",
+      "version": "0.19.0-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/libg/libgav1/libgav1-1_0.19.0-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgc1",
+      "version": "1:8.2.8-1",
+      "architecture": "amd64",
+      "link": "pool/main/libg/libgc/libgc1_8.2.8-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgc1",
+      "version": "1:8.2.8-1",
+      "architecture": "arm64",
+      "link": "pool/main/libg/libgc/libgc1_8.2.8-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgcc-13-dev",
+      "version": "13.3.0-16",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-13/libgcc-13-dev_13.3.0-16_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgcc-13-dev",
+      "version": "13.3.0-16",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-13/libgcc-13-dev_13.3.0-16_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgcc-14-dev",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/libgcc-14-dev_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgcc-14-dev",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/libgcc-14-dev_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgcc-s1",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/libgcc-s1_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgcc-s1",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/libgcc-s1_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgcrypt20",
+      "version": "1.11.0-7",
+      "architecture": "amd64",
+      "link": "pool/main/libg/libgcrypt20/libgcrypt20_1.11.0-7_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgcrypt20",
+      "version": "1.11.0-7",
+      "architecture": "arm64",
+      "link": "pool/main/libg/libgcrypt20/libgcrypt20_1.11.0-7_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgd3",
+      "version": "2.3.3-13+0~20260506.19+debian13~1.gbp4c9a22",
+      "architecture": "amd64",
+      "link": "pool/main/libg/libgd2/libgd3_2.3.3-13+0~20260506.19+debian13~1.gbp4c9a22_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgd3",
+      "version": "2.3.3-13+0~20260506.19+debian13~1.gbp4c9a22",
+      "architecture": "arm64",
+      "link": "pool/main/libg/libgd2/libgd3_2.3.3-13+0~20260506.19+debian13~1.gbp4c9a22_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgdbm-compat4t64",
+      "version": "1.24-2",
+      "architecture": "amd64",
+      "link": "pool/main/g/gdbm/libgdbm-compat4t64_1.24-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgdbm-compat4t64",
+      "version": "1.24-2",
+      "architecture": "arm64",
+      "link": "pool/main/g/gdbm/libgdbm-compat4t64_1.24-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgdbm6t64",
+      "version": "1.24-2",
+      "architecture": "amd64",
+      "link": "pool/main/g/gdbm/libgdbm6t64_1.24-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgdbm6t64",
+      "version": "1.24-2",
+      "architecture": "arm64",
+      "link": "pool/main/g/gdbm/libgdbm6t64_1.24-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libglib2.0-0t64",
+      "version": "2.84.4-3~deb13u3",
+      "architecture": "amd64",
+      "link": "pool/main/g/glib2.0/libglib2.0-0t64_2.84.4-3~deb13u3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libglib2.0-0t64",
+      "version": "2.84.4-3~deb13u3",
+      "architecture": "arm64",
+      "link": "pool/main/g/glib2.0/libglib2.0-0t64_2.84.4-3~deb13u3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgmp10",
+      "version": "2:6.3.0+dfsg-3",
+      "architecture": "amd64",
+      "link": "pool/main/g/gmp/libgmp10_6.3.0+dfsg-3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgmp10",
+      "version": "2:6.3.0+dfsg-3",
+      "architecture": "arm64",
+      "link": "pool/main/g/gmp/libgmp10_6.3.0+dfsg-3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgnutls30t64",
+      "version": "3.8.9-3+deb13u3",
+      "architecture": "amd64",
+      "link": "pool/main/g/gnutls28/libgnutls30t64_3.8.9-3+deb13u3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgnutls30t64",
+      "version": "3.8.9-3+deb13u3",
+      "architecture": "arm64",
+      "link": "pool/main/g/gnutls28/libgnutls30t64_3.8.9-3+deb13u3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgomp1",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/libgomp1_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgomp1",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/libgomp1_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgpg-error0",
+      "version": "1.51-4",
+      "architecture": "amd64",
+      "link": "pool/main/libg/libgpg-error/libgpg-error0_1.51-4_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgpg-error0",
+      "version": "1.51-4",
+      "architecture": "arm64",
+      "link": "pool/main/libg/libgpg-error/libgpg-error0_1.51-4_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgprofng0",
+      "version": "2.44-3",
+      "architecture": "amd64",
+      "link": "pool/main/b/binutils/libgprofng0_2.44-3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgprofng0",
+      "version": "2.44-3",
+      "architecture": "arm64",
+      "link": "pool/main/b/binutils/libgprofng0_2.44-3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgssapi-krb5-2",
+      "version": "1.21.3-5",
+      "architecture": "amd64",
+      "link": "pool/main/k/krb5/libgssapi-krb5-2_1.21.3-5_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libgssapi-krb5-2",
+      "version": "1.21.3-5",
+      "architecture": "arm64",
+      "link": "pool/main/k/krb5/libgssapi-krb5-2_1.21.3-5_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libheif-plugin-dav1d",
+      "version": "1.19.8-1",
+      "architecture": "amd64",
+      "link": "pool/main/libh/libheif/libheif-plugin-dav1d_1.19.8-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libheif-plugin-dav1d",
+      "version": "1.19.8-1",
+      "architecture": "arm64",
+      "link": "pool/main/libh/libheif/libheif-plugin-dav1d_1.19.8-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libheif-plugin-libde265",
+      "version": "1.19.8-1",
+      "architecture": "amd64",
+      "link": "pool/main/libh/libheif/libheif-plugin-libde265_1.19.8-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libheif-plugin-libde265",
+      "version": "1.19.8-1",
+      "architecture": "arm64",
+      "link": "pool/main/libh/libheif/libheif-plugin-libde265_1.19.8-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libheif1",
+      "version": "1.19.8-1",
+      "architecture": "amd64",
+      "link": "pool/main/libh/libheif/libheif1_1.19.8-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libheif1",
+      "version": "1.19.8-1",
+      "architecture": "arm64",
+      "link": "pool/main/libh/libheif/libheif1_1.19.8-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libhogweed6t64",
+      "version": "3.10.1-1",
+      "architecture": "amd64",
+      "link": "pool/main/n/nettle/libhogweed6t64_3.10.1-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libhogweed6t64",
+      "version": "3.10.1-1",
+      "architecture": "arm64",
+      "link": "pool/main/n/nettle/libhogweed6t64_3.10.1-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libhwasan0",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/libhwasan0_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libhwasan0",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/libhwasan0_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libicu76",
+      "version": "76.1-4",
+      "architecture": "amd64",
+      "link": "pool/main/i/icu/libicu76_76.1-4_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libicu76",
+      "version": "76.1-4",
+      "architecture": "arm64",
+      "link": "pool/main/i/icu/libicu76_76.1-4_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libidn2-0",
+      "version": "2.3.8-2",
+      "architecture": "amd64",
+      "link": "pool/main/libi/libidn2/libidn2-0_2.3.8-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libidn2-0",
+      "version": "2.3.8-2",
+      "architecture": "arm64",
+      "link": "pool/main/libi/libidn2/libidn2-0_2.3.8-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libimagequant0",
+      "version": "2.18.0-1+b2",
+      "architecture": "amd64",
+      "link": "pool/main/libi/libimagequant/libimagequant0_2.18.0-1+b2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libimagequant0",
+      "version": "2.18.0-1+b2",
+      "architecture": "arm64",
+      "link": "pool/main/libi/libimagequant/libimagequant0_2.18.0-1+b2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libipt2",
+      "version": "2.1.2-1",
+      "architecture": "amd64",
+      "link": "pool/main/i/intel-processor-trace/libipt2_2.1.2-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libisl23",
+      "version": "0.27-1",
+      "architecture": "amd64",
+      "link": "pool/main/i/isl/libisl23_0.27-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libisl23",
+      "version": "0.27-1",
+      "architecture": "arm64",
+      "link": "pool/main/i/isl/libisl23_0.27-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libitm1",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/libitm1_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libitm1",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/libitm1_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libjansson4",
+      "version": "2.14-2+b3",
+      "architecture": "amd64",
+      "link": "pool/main/j/jansson/libjansson4_2.14-2+b3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libjansson4",
+      "version": "2.14-2+b3",
+      "architecture": "arm64",
+      "link": "pool/main/j/jansson/libjansson4_2.14-2+b3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libjbig0",
+      "version": "2.1-6.1+b2",
+      "architecture": "amd64",
+      "link": "pool/main/j/jbigkit/libjbig0_2.1-6.1+b2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libjbig0",
+      "version": "2.1-6.1+b2",
+      "architecture": "arm64",
+      "link": "pool/main/j/jbigkit/libjbig0_2.1-6.1+b2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libjpeg62-turbo",
+      "version": "1:2.1.5-4",
+      "architecture": "amd64",
+      "link": "pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-4_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libjpeg62-turbo",
+      "version": "1:2.1.5-4",
+      "architecture": "arm64",
+      "link": "pool/main/libj/libjpeg-turbo/libjpeg62-turbo_2.1.5-4_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libjs-jquery",
+      "version": "3.6.1+dfsg+~3.5.14-1",
+      "architecture": "all",
+      "link": "pool/main/n/node-jquery/libjs-jquery_3.6.1+dfsg+~3.5.14-1_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libjs-sphinxdoc",
+      "version": "8.1.3-5",
+      "architecture": "all",
+      "link": "pool/main/s/sphinx/libjs-sphinxdoc_8.1.3-5_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libjs-underscore",
+      "version": "1.13.4~dfsg+~1.11.4-3",
+      "architecture": "all",
+      "link": "pool/main/u/underscore/libjs-underscore_1.13.4~dfsg+~1.11.4-3_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libjson-c5",
+      "version": "0.18+ds-1",
+      "architecture": "amd64",
+      "link": "pool/main/j/json-c/libjson-c5_0.18+ds-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libjson-c5",
+      "version": "0.18+ds-1",
+      "architecture": "arm64",
+      "link": "pool/main/j/json-c/libjson-c5_0.18+ds-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libjsoncpp26",
+      "version": "1.9.6-3",
+      "architecture": "amd64",
+      "link": "pool/main/libj/libjsoncpp/libjsoncpp26_1.9.6-3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libjsoncpp26",
+      "version": "1.9.6-3",
+      "architecture": "arm64",
+      "link": "pool/main/libj/libjsoncpp/libjsoncpp26_1.9.6-3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libk5crypto3",
+      "version": "1.21.3-5",
+      "architecture": "amd64",
+      "link": "pool/main/k/krb5/libk5crypto3_1.21.3-5_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libk5crypto3",
+      "version": "1.21.3-5",
+      "architecture": "arm64",
+      "link": "pool/main/k/krb5/libk5crypto3_1.21.3-5_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libkeyutils1",
+      "version": "1.6.3-6",
+      "architecture": "amd64",
+      "link": "pool/main/k/keyutils/libkeyutils1_1.6.3-6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libkeyutils1",
+      "version": "1.6.3-6",
+      "architecture": "arm64",
+      "link": "pool/main/k/keyutils/libkeyutils1_1.6.3-6_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libkrb5-3",
+      "version": "1.21.3-5",
+      "architecture": "amd64",
+      "link": "pool/main/k/krb5/libkrb5-3_1.21.3-5_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libkrb5-3",
+      "version": "1.21.3-5",
+      "architecture": "arm64",
+      "link": "pool/main/k/krb5/libkrb5-3_1.21.3-5_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libkrb5support0",
+      "version": "1.21.3-5",
+      "architecture": "amd64",
+      "link": "pool/main/k/krb5/libkrb5support0_1.21.3-5_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libkrb5support0",
+      "version": "1.21.3-5",
+      "architecture": "arm64",
+      "link": "pool/main/k/krb5/libkrb5support0_1.21.3-5_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libldap2",
+      "version": "2.6.10+dfsg-1",
+      "architecture": "amd64",
+      "link": "pool/main/o/openldap/libldap2_2.6.10+dfsg-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libldap2",
+      "version": "2.6.10+dfsg-1",
+      "architecture": "arm64",
+      "link": "pool/main/o/openldap/libldap2_2.6.10+dfsg-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "liblerc4",
+      "version": "4.0.0+ds-5",
+      "architecture": "amd64",
+      "link": "pool/main/l/lerc/liblerc4_4.0.0+ds-5_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "liblerc4",
+      "version": "4.0.0+ds-5",
+      "architecture": "arm64",
+      "link": "pool/main/l/lerc/liblerc4_4.0.0+ds-5_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "liblldb-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-toolchain-19/liblldb-19_19.1.7-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "liblldb-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-toolchain-19/liblldb-19_19.1.7-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libllvm19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-toolchain-19/libllvm19_19.1.7-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libllvm19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-toolchain-19/libllvm19_19.1.7-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "liblsan0",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/liblsan0_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "liblsan0",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/liblsan0_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "liblua5.4-0",
+      "version": "5.4.7-1+b2",
+      "architecture": "amd64",
+      "link": "pool/main/l/lua5.4/liblua5.4-0_5.4.7-1+b2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "liblua5.4-0",
+      "version": "5.4.7-1+b2",
+      "architecture": "arm64",
+      "link": "pool/main/l/lua5.4/liblua5.4-0_5.4.7-1+b2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "liblz4-1",
+      "version": "1.10.0-4",
+      "architecture": "amd64",
+      "link": "pool/main/l/lz4/liblz4-1_1.10.0-4_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "liblz4-1",
+      "version": "1.10.0-4",
+      "architecture": "arm64",
+      "link": "pool/main/l/lz4/liblz4-1_1.10.0-4_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "liblzma5",
+      "version": "5.8.1-1",
+      "architecture": "amd64",
+      "link": "pool/main/x/xz-utils/liblzma5_5.8.1-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "liblzma5",
+      "version": "5.8.1-1",
+      "architecture": "arm64",
+      "link": "pool/main/x/xz-utils/liblzma5_5.8.1-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libmaxminddb0",
+      "version": "1.12.2-1",
+      "architecture": "amd64",
+      "link": "pool/main/libm/libmaxminddb/libmaxminddb0_1.12.2-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libmaxminddb0",
+      "version": "1.12.2-1",
+      "architecture": "arm64",
+      "link": "pool/main/libm/libmaxminddb/libmaxminddb0_1.12.2-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libmd0",
+      "version": "1.1.0-2+b1",
+      "architecture": "amd64",
+      "link": "pool/main/libm/libmd/libmd0_1.1.0-2+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libmd0",
+      "version": "1.1.0-2+b1",
+      "architecture": "arm64",
+      "link": "pool/main/libm/libmd/libmd0_1.1.0-2+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libmount1",
+      "version": "2.41-5",
+      "architecture": "amd64",
+      "link": "pool/main/u/util-linux/libmount1_2.41-5_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libmount1",
+      "version": "2.41-5",
+      "architecture": "arm64",
+      "link": "pool/main/u/util-linux/libmount1_2.41-5_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libmpc3",
+      "version": "1.3.1-1+b3",
+      "architecture": "amd64",
+      "link": "pool/main/m/mpclib3/libmpc3_1.3.1-1+b3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libmpc3",
+      "version": "1.3.1-1+b3",
+      "architecture": "arm64",
+      "link": "pool/main/m/mpclib3/libmpc3_1.3.1-1+b3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libmpfr6",
+      "version": "4.2.2-1",
+      "architecture": "amd64",
+      "link": "pool/main/m/mpfr4/libmpfr6_4.2.2-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libmpfr6",
+      "version": "4.2.2-1",
+      "architecture": "arm64",
+      "link": "pool/main/m/mpfr4/libmpfr6_4.2.2-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libncurses6",
+      "version": "6.5+20250216-2",
+      "architecture": "amd64",
+      "link": "pool/main/n/ncurses/libncurses6_6.5+20250216-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libncurses6",
+      "version": "6.5+20250216-2",
+      "architecture": "arm64",
+      "link": "pool/main/n/ncurses/libncurses6_6.5+20250216-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libncursesw6",
+      "version": "6.5+20250216-2",
+      "architecture": "amd64",
+      "link": "pool/main/n/ncurses/libncursesw6_6.5+20250216-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libncursesw6",
+      "version": "6.5+20250216-2",
+      "architecture": "arm64",
+      "link": "pool/main/n/ncurses/libncursesw6_6.5+20250216-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libnettle8t64",
+      "version": "3.10.1-1",
+      "architecture": "amd64",
+      "link": "pool/main/n/nettle/libnettle8t64_3.10.1-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libnettle8t64",
+      "version": "3.10.1-1",
+      "architecture": "arm64",
+      "link": "pool/main/n/nettle/libnettle8t64_3.10.1-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libnghttp2-14",
+      "version": "1.64.0-1.1",
+      "architecture": "amd64",
+      "link": "pool/main/n/nghttp2/libnghttp2-14_1.64.0-1.1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libnghttp2-14",
+      "version": "1.64.0-1.1",
+      "architecture": "arm64",
+      "link": "pool/main/n/nghttp2/libnghttp2-14_1.64.0-1.1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libnghttp3-9",
+      "version": "1.8.0-1",
+      "architecture": "amd64",
+      "link": "pool/main/n/nghttp3/libnghttp3-9_1.8.0-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libnghttp3-9",
+      "version": "1.8.0-1",
+      "architecture": "arm64",
+      "link": "pool/main/n/nghttp3/libnghttp3-9_1.8.0-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libngtcp2-16",
+      "version": "1.11.0-1+deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/n/ngtcp2/libngtcp2-16_1.11.0-1+deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libngtcp2-16",
+      "version": "1.11.0-1+deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/n/ngtcp2/libngtcp2-16_1.11.0-1+deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libngtcp2-crypto-gnutls8",
+      "version": "1.11.0-1+deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.11.0-1+deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libngtcp2-crypto-gnutls8",
+      "version": "1.11.0-1+deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/n/ngtcp2/libngtcp2-crypto-gnutls8_1.11.0-1+deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libnl-3-200",
+      "version": "3.7.0-2",
+      "architecture": "amd64",
+      "link": "pool/main/libn/libnl3/libnl-3-200_3.7.0-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libnl-3-200",
+      "version": "3.7.0-2",
+      "architecture": "arm64",
+      "link": "pool/main/libn/libnl3/libnl-3-200_3.7.0-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libnl-genl-3-200",
+      "version": "3.7.0-2",
+      "architecture": "amd64",
+      "link": "pool/main/libn/libnl3/libnl-genl-3-200_3.7.0-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libnl-genl-3-200",
+      "version": "3.7.0-2",
+      "architecture": "arm64",
+      "link": "pool/main/libn/libnl3/libnl-genl-3-200_3.7.0-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libnl-route-3-200",
+      "version": "3.7.0-2",
+      "architecture": "amd64",
+      "link": "pool/main/libn/libnl3/libnl-route-3-200_3.7.0-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libnl-route-3-200",
+      "version": "3.7.0-2",
+      "architecture": "arm64",
+      "link": "pool/main/libn/libnl3/libnl-route-3-200_3.7.0-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libobjc-14-dev",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/libobjc-14-dev_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libobjc-14-dev",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/libobjc-14-dev_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libobjc4",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/libobjc4_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libobjc4",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/libobjc4_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libonig5",
+      "version": "6.9.9-1+b1",
+      "architecture": "amd64",
+      "link": "pool/main/libo/libonig/libonig5_6.9.9-1+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libonig5",
+      "version": "6.9.9-1+b1",
+      "architecture": "arm64",
+      "link": "pool/main/libo/libonig/libonig5_6.9.9-1+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libopencore-amrnb0",
+      "version": "0.1.6-1+b2",
+      "architecture": "amd64",
+      "link": "pool/main/o/opencore-amr/libopencore-amrnb0_0.1.6-1+b2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libopencore-amrnb0",
+      "version": "0.1.6-1+b2",
+      "architecture": "arm64",
+      "link": "pool/main/o/opencore-amr/libopencore-amrnb0_0.1.6-1+b2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libopus0",
+      "version": "1.5.2-2",
+      "architecture": "amd64",
+      "link": "pool/main/o/opus/libopus0_1.5.2-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libopus0",
+      "version": "1.5.2-2",
+      "architecture": "arm64",
+      "link": "pool/main/o/opus/libopus0_1.5.2-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libp11-kit0",
+      "version": "0.25.5-3",
+      "architecture": "amd64",
+      "link": "pool/main/p/p11-kit/libp11-kit0_0.25.5-3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libp11-kit0",
+      "version": "0.25.5-3",
+      "architecture": "arm64",
+      "link": "pool/main/p/p11-kit/libp11-kit0_0.25.5-3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpcap0.8t64",
+      "version": "1.10.5-2",
+      "architecture": "amd64",
+      "link": "pool/main/libp/libpcap/libpcap0.8t64_1.10.5-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpcap0.8t64",
+      "version": "1.10.5-2",
+      "architecture": "arm64",
+      "link": "pool/main/libp/libpcap/libpcap0.8t64_1.10.5-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpcre2-8-0",
+      "version": "10.46-1~deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/p/pcre2/libpcre2-8-0_10.46-1~deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpcre2-8-0",
+      "version": "10.46-1~deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/p/pcre2/libpcre2-8-0_10.46-1~deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libperl5.40",
+      "version": "5.40.1-6",
+      "architecture": "amd64",
+      "link": "pool/main/p/perl/libperl5.40_5.40.1-6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libperl5.40",
+      "version": "5.40.1-6",
+      "architecture": "arm64",
+      "link": "pool/main/p/perl/libperl5.40_5.40.1-6_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpng16-16t64",
+      "version": "1.6.48-1+deb13u5",
+      "architecture": "amd64",
+      "link": "pool/main/libp/libpng1.6/libpng16-16t64_1.6.48-1+deb13u5_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpng16-16t64",
+      "version": "1.6.48-1+deb13u5",
+      "architecture": "arm64",
+      "link": "pool/main/libp/libpng1.6/libpng16-16t64_1.6.48-1+deb13u5_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpq5",
+      "version": "17.9-0+deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/p/postgresql-17/libpq5_17.9-0+deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpq5",
+      "version": "17.9-0+deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/p/postgresql-17/libpq5_17.9-0+deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libproc2-0",
+      "version": "2:4.0.4-9",
+      "architecture": "amd64",
+      "link": "pool/main/p/procps/libproc2-0_4.0.4-9_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libproc2-0",
+      "version": "2:4.0.4-9",
+      "architecture": "arm64",
+      "link": "pool/main/p/procps/libproc2-0_4.0.4-9_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpsl5t64",
+      "version": "0.21.2-1.1+b1",
+      "architecture": "amd64",
+      "link": "pool/main/libp/libpsl/libpsl5t64_0.21.2-1.1+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpsl5t64",
+      "version": "0.21.2-1.1+b1",
+      "architecture": "arm64",
+      "link": "pool/main/libp/libpsl/libpsl5t64_0.21.2-1.1+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpython3-dev",
+      "version": "3.13.5-1",
+      "architecture": "amd64",
+      "link": "pool/main/p/python3-defaults/libpython3-dev_3.13.5-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpython3-dev",
+      "version": "3.13.5-1",
+      "architecture": "arm64",
+      "link": "pool/main/p/python3-defaults/libpython3-dev_3.13.5-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpython3-stdlib",
+      "version": "3.13.5-1",
+      "architecture": "amd64",
+      "link": "pool/main/p/python3-defaults/libpython3-stdlib_3.13.5-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpython3-stdlib",
+      "version": "3.13.5-1",
+      "architecture": "arm64",
+      "link": "pool/main/p/python3-defaults/libpython3-stdlib_3.13.5-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpython3.13",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "amd64",
+      "link": "pool/main/p/python3.13/libpython3.13_3.13.5-2+deb13u2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpython3.13",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "arm64",
+      "link": "pool/main/p/python3.13/libpython3.13_3.13.5-2+deb13u2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpython3.13-dev",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "amd64",
+      "link": "pool/main/p/python3.13/libpython3.13-dev_3.13.5-2+deb13u2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpython3.13-dev",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "arm64",
+      "link": "pool/main/p/python3.13/libpython3.13-dev_3.13.5-2+deb13u2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpython3.13-minimal",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "amd64",
+      "link": "pool/main/p/python3.13/libpython3.13-minimal_3.13.5-2+deb13u2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpython3.13-minimal",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "arm64",
+      "link": "pool/main/p/python3.13/libpython3.13-minimal_3.13.5-2+deb13u2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpython3.13-stdlib",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "amd64",
+      "link": "pool/main/p/python3.13/libpython3.13-stdlib_3.13.5-2+deb13u2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libpython3.13-stdlib",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "arm64",
+      "link": "pool/main/p/python3.13/libpython3.13-stdlib_3.13.5-2+deb13u2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libquadmath0",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/libquadmath0_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "librav1e0.7",
+      "version": "0.7.1-9+b2",
+      "architecture": "amd64",
+      "link": "pool/main/r/rust-rav1e/librav1e0.7_0.7.1-9+b2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "librav1e0.7",
+      "version": "0.7.1-9+b2",
+      "architecture": "arm64",
+      "link": "pool/main/r/rust-rav1e/librav1e0.7_0.7.1-9+b2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libreadline8t64",
+      "version": "8.2-6",
+      "architecture": "amd64",
+      "link": "pool/main/r/readline/libreadline8t64_8.2-6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libreadline8t64",
+      "version": "8.2-6",
+      "architecture": "arm64",
+      "link": "pool/main/r/readline/libreadline8t64_8.2-6_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "librhash1",
+      "version": "1.4.5-1",
+      "architecture": "amd64",
+      "link": "pool/main/r/rhash/librhash1_1.4.5-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "librhash1",
+      "version": "1.4.5-1",
+      "architecture": "arm64",
+      "link": "pool/main/r/rhash/librhash1_1.4.5-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "librtmp1",
+      "version": "2.4+20151223.gitfa8646d.1-2+b5",
+      "architecture": "amd64",
+      "link": "pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-2+b5_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "librtmp1",
+      "version": "2.4+20151223.gitfa8646d.1-2+b5",
+      "architecture": "arm64",
+      "link": "pool/main/r/rtmpdump/librtmp1_2.4+20151223.gitfa8646d.1-2+b5_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsasl2-2",
+      "version": "2.1.28+dfsg1-9",
+      "architecture": "amd64",
+      "link": "pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-9_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsasl2-2",
+      "version": "2.1.28+dfsg1-9",
+      "architecture": "arm64",
+      "link": "pool/main/c/cyrus-sasl2/libsasl2-2_2.1.28+dfsg1-9_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsasl2-modules-db",
+      "version": "2.1.28+dfsg1-9",
+      "architecture": "amd64",
+      "link": "pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-9_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsasl2-modules-db",
+      "version": "2.1.28+dfsg1-9",
+      "architecture": "arm64",
+      "link": "pool/main/c/cyrus-sasl2/libsasl2-modules-db_2.1.28+dfsg1-9_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsbc1",
+      "version": "2.1-1",
+      "architecture": "amd64",
+      "link": "pool/main/s/sbc/libsbc1_2.1-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsbc1",
+      "version": "2.1-1",
+      "architecture": "arm64",
+      "link": "pool/main/s/sbc/libsbc1_2.1-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libselinux1",
+      "version": "3.8.1-1",
+      "architecture": "amd64",
+      "link": "pool/main/libs/libselinux/libselinux1_3.8.1-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libselinux1",
+      "version": "3.8.1-1",
+      "architecture": "arm64",
+      "link": "pool/main/libs/libselinux/libselinux1_3.8.1-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsframe1",
+      "version": "2.44-3",
+      "architecture": "amd64",
+      "link": "pool/main/b/binutils/libsframe1_2.44-3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsframe1",
+      "version": "2.44-3",
+      "architecture": "arm64",
+      "link": "pool/main/b/binutils/libsframe1_2.44-3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsharpyuv0",
+      "version": "1.5.0-0.1",
+      "architecture": "amd64",
+      "link": "pool/main/libw/libwebp/libsharpyuv0_1.5.0-0.1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsharpyuv0",
+      "version": "1.5.0-0.1",
+      "architecture": "arm64",
+      "link": "pool/main/libw/libwebp/libsharpyuv0_1.5.0-0.1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsmi2t64",
+      "version": "0.4.8+dfsg2-17+b1",
+      "architecture": "amd64",
+      "link": "pool/main/libs/libsmi/libsmi2t64_0.4.8+dfsg2-17+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsmi2t64",
+      "version": "0.4.8+dfsg2-17+b1",
+      "architecture": "arm64",
+      "link": "pool/main/libs/libsmi/libsmi2t64_0.4.8+dfsg2-17+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsnappy1v5",
+      "version": "1.2.2-1",
+      "architecture": "amd64",
+      "link": "pool/main/s/snappy/libsnappy1v5_1.2.2-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsnappy1v5",
+      "version": "1.2.2-1",
+      "architecture": "arm64",
+      "link": "pool/main/s/snappy/libsnappy1v5_1.2.2-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsodium23",
+      "version": "1.0.18-1+deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/libs/libsodium/libsodium23_1.0.18-1+deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsodium23",
+      "version": "1.0.18-1+deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/libs/libsodium/libsodium23_1.0.18-1+deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsource-highlight-common",
+      "version": "3.1.9-4.3",
+      "architecture": "all",
+      "link": "pool/main/s/source-highlight/libsource-highlight-common_3.1.9-4.3_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsource-highlight4t64",
+      "version": "3.1.9-4.3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/s/source-highlight/libsource-highlight4t64_3.1.9-4.3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsource-highlight4t64",
+      "version": "3.1.9-4.3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/s/source-highlight/libsource-highlight4t64_3.1.9-4.3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libspandsp2t64",
+      "version": "0.0.6+dfsg-2.2",
+      "architecture": "amd64",
+      "link": "pool/main/s/spandsp/libspandsp2t64_0.0.6+dfsg-2.2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libspandsp2t64",
+      "version": "0.0.6+dfsg-2.2",
+      "architecture": "arm64",
+      "link": "pool/main/s/spandsp/libspandsp2t64_0.0.6+dfsg-2.2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libspeexdsp1",
+      "version": "1.2.1-3",
+      "architecture": "amd64",
+      "link": "pool/main/s/speexdsp/libspeexdsp1_1.2.1-3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libspeexdsp1",
+      "version": "1.2.1-3",
+      "architecture": "arm64",
+      "link": "pool/main/s/speexdsp/libspeexdsp1_1.2.1-3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsqlite3-0",
+      "version": "3.46.1-7+deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/s/sqlite3/libsqlite3-0_3.46.1-7+deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsqlite3-0",
+      "version": "3.46.1-7+deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/s/sqlite3/libsqlite3-0_3.46.1-7+deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libssh-4",
+      "version": "0.11.2-1+deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/libs/libssh/libssh-4_0.11.2-1+deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libssh-4",
+      "version": "0.11.2-1+deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/libs/libssh/libssh-4_0.11.2-1+deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libssh2-1t64",
+      "version": "1.11.1-1",
+      "architecture": "amd64",
+      "link": "pool/main/libs/libssh2/libssh2-1t64_1.11.1-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libssh2-1t64",
+      "version": "1.11.1-1",
+      "architecture": "arm64",
+      "link": "pool/main/libs/libssh2/libssh2-1t64_1.11.1-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libssl3t64",
+      "version": "3.5.6-1~deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/o/openssl/libssl3t64_3.5.6-1~deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libssl3t64",
+      "version": "3.5.6-1~deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/o/openssl/libssl3t64_3.5.6-1~deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libstdc++-13-dev",
+      "version": "13.3.0-16",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-13/libstdc++-13-dev_13.3.0-16_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libstdc++-13-dev",
+      "version": "13.3.0-16",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-13/libstdc++-13-dev_13.3.0-16_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libstdc++-14-dev",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/libstdc++-14-dev_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libstdc++-14-dev",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/libstdc++-14-dev_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libstdc++6",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/libstdc++6_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libstdc++6",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/libstdc++6_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsvtav1enc2",
+      "version": "2.3.0+dfsg-1",
+      "architecture": "amd64",
+      "link": "pool/main/s/svt-av1/libsvtav1enc2_2.3.0+dfsg-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsvtav1enc2",
+      "version": "2.3.0+dfsg-1",
+      "architecture": "arm64",
+      "link": "pool/main/s/svt-av1/libsvtav1enc2_2.3.0+dfsg-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsystemd0",
+      "version": "257.13-1~deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/s/systemd/libsystemd0_257.13-1~deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libsystemd0",
+      "version": "257.13-1~deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/s/systemd/libsystemd0_257.13-1~deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libtasn1-6",
+      "version": "4.20.0-2",
+      "architecture": "amd64",
+      "link": "pool/main/libt/libtasn1-6/libtasn1-6_4.20.0-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libtasn1-6",
+      "version": "4.20.0-2",
+      "architecture": "arm64",
+      "link": "pool/main/libt/libtasn1-6/libtasn1-6_4.20.0-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libtext-charwidth-perl",
+      "version": "0.04-11+b4",
+      "architecture": "amd64",
+      "link": "pool/main/libt/libtext-charwidth-perl/libtext-charwidth-perl_0.04-11+b4_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libtext-charwidth-perl",
+      "version": "0.04-11+b4",
+      "architecture": "arm64",
+      "link": "pool/main/libt/libtext-charwidth-perl/libtext-charwidth-perl_0.04-11+b4_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libtext-wrapi18n-perl",
+      "version": "0.06-10",
+      "architecture": "all",
+      "link": "pool/main/libt/libtext-wrapi18n-perl/libtext-wrapi18n-perl_0.06-10_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libtiff6",
+      "version": "4.7.0-3+deb13u2",
+      "architecture": "amd64",
+      "link": "pool/main/t/tiff/libtiff6_4.7.0-3+deb13u2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libtiff6",
+      "version": "4.7.0-3+deb13u2",
+      "architecture": "arm64",
+      "link": "pool/main/t/tiff/libtiff6_4.7.0-3+deb13u2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libtinfo6",
+      "version": "6.5+20250216-2",
+      "architecture": "amd64",
+      "link": "pool/main/n/ncurses/libtinfo6_6.5+20250216-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libtinfo6",
+      "version": "6.5+20250216-2",
+      "architecture": "arm64",
+      "link": "pool/main/n/ncurses/libtinfo6_6.5+20250216-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libtsan2",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/libtsan2_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libtsan2",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/libtsan2_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libubsan1",
+      "version": "14.2.0-19",
+      "architecture": "amd64",
+      "link": "pool/main/g/gcc-14/libubsan1_14.2.0-19_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libubsan1",
+      "version": "14.2.0-19",
+      "architecture": "arm64",
+      "link": "pool/main/g/gcc-14/libubsan1_14.2.0-19_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libudev1",
+      "version": "257.13-1~deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/s/systemd/libudev1_257.13-1~deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libudev1",
+      "version": "257.13-1~deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/s/systemd/libudev1_257.13-1~deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libunistring5",
+      "version": "1.3-2",
+      "architecture": "amd64",
+      "link": "pool/main/libu/libunistring/libunistring5_1.3-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libunistring5",
+      "version": "1.3-2",
+      "architecture": "arm64",
+      "link": "pool/main/libu/libunistring/libunistring5_1.3-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libuuid1",
+      "version": "2.41-5",
+      "architecture": "amd64",
+      "link": "pool/main/u/util-linux/libuuid1_2.41-5_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libuuid1",
+      "version": "2.41-5",
+      "architecture": "arm64",
+      "link": "pool/main/u/util-linux/libuuid1_2.41-5_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libuv1t64",
+      "version": "1.50.0-2",
+      "architecture": "amd64",
+      "link": "pool/main/libu/libuv1/libuv1t64_1.50.0-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libuv1t64",
+      "version": "1.50.0-2",
+      "architecture": "arm64",
+      "link": "pool/main/libu/libuv1/libuv1t64_1.50.0-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libwebp7",
+      "version": "1.5.0-0.1",
+      "architecture": "amd64",
+      "link": "pool/main/libw/libwebp/libwebp7_1.5.0-0.1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libwebp7",
+      "version": "1.5.0-0.1",
+      "architecture": "arm64",
+      "link": "pool/main/libw/libwebp/libwebp7_1.5.0-0.1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libwireshark-data",
+      "version": "4.4.15-0+deb13u1",
+      "architecture": "all",
+      "link": "pool/main/w/wireshark/libwireshark-data_4.4.15-0+deb13u1_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libwireshark18",
+      "version": "4.4.15-0+deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/w/wireshark/libwireshark18_4.4.15-0+deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libwireshark18",
+      "version": "4.4.15-0+deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/w/wireshark/libwireshark18_4.4.15-0+deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libwiretap15",
+      "version": "4.4.15-0+deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/w/wireshark/libwiretap15_4.4.15-0+deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libwiretap15",
+      "version": "4.4.15-0+deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/w/wireshark/libwiretap15_4.4.15-0+deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libwsutil16",
+      "version": "4.4.15-0+deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/w/wireshark/libwsutil16_4.4.15-0+deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libwsutil16",
+      "version": "4.4.15-0+deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/w/wireshark/libwsutil16_4.4.15-0+deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libx11-6",
+      "version": "2:1.8.12-1",
+      "architecture": "amd64",
+      "link": "pool/main/libx/libx11/libx11-6_1.8.12-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libx11-6",
+      "version": "2:1.8.12-1",
+      "architecture": "arm64",
+      "link": "pool/main/libx/libx11/libx11-6_1.8.12-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libx11-data",
+      "version": "2:1.8.12-1",
+      "architecture": "all",
+      "link": "pool/main/libx/libx11/libx11-data_1.8.12-1_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libxau6",
+      "version": "1:1.0.11-1",
+      "architecture": "amd64",
+      "link": "pool/main/libx/libxau/libxau6_1.0.11-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libxau6",
+      "version": "1:1.0.11-1",
+      "architecture": "arm64",
+      "link": "pool/main/libx/libxau/libxau6_1.0.11-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libxcb1",
+      "version": "1.17.0-2+b1",
+      "architecture": "amd64",
+      "link": "pool/main/libx/libxcb/libxcb1_1.17.0-2+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libxcb1",
+      "version": "1.17.0-2+b1",
+      "architecture": "arm64",
+      "link": "pool/main/libx/libxcb/libxcb1_1.17.0-2+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libxdmcp6",
+      "version": "1:1.1.5-1",
+      "architecture": "amd64",
+      "link": "pool/main/libx/libxdmcp/libxdmcp6_1.1.5-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libxdmcp6",
+      "version": "1:1.1.5-1",
+      "architecture": "arm64",
+      "link": "pool/main/libx/libxdmcp/libxdmcp6_1.1.5-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libxml2",
+      "version": "2.12.7+dfsg+really2.9.14-2.1+deb13u2",
+      "architecture": "amd64",
+      "link": "pool/main/libx/libxml2/libxml2_2.12.7+dfsg+really2.9.14-2.1+deb13u2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libxml2",
+      "version": "2.12.7+dfsg+really2.9.14-2.1+deb13u2",
+      "architecture": "arm64",
+      "link": "pool/main/libx/libxml2/libxml2_2.12.7+dfsg+really2.9.14-2.1+deb13u2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libxpm4",
+      "version": "1:3.5.17-1+b3",
+      "architecture": "amd64",
+      "link": "pool/main/libx/libxpm/libxpm4_3.5.17-1+b3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libxpm4",
+      "version": "1:3.5.17-1+b3",
+      "architecture": "arm64",
+      "link": "pool/main/libx/libxpm/libxpm4_3.5.17-1+b3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libxslt1.1",
+      "version": "1.1.35-1.2+deb13u3",
+      "architecture": "amd64",
+      "link": "pool/main/libx/libxslt/libxslt1.1_1.1.35-1.2+deb13u3_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libxslt1.1",
+      "version": "1.1.35-1.2+deb13u3",
+      "architecture": "arm64",
+      "link": "pool/main/libx/libxslt/libxslt1.1_1.1.35-1.2+deb13u3_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libxxhash0",
+      "version": "0.8.3-2",
+      "architecture": "amd64",
+      "link": "pool/main/x/xxhash/libxxhash0_0.8.3-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libxxhash0",
+      "version": "0.8.3-2",
+      "architecture": "arm64",
+      "link": "pool/main/x/xxhash/libxxhash0_0.8.3-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libyaml-0-2",
+      "version": "0.2.5-2",
+      "architecture": "amd64",
+      "link": "pool/main/liby/libyaml/libyaml-0-2_0.2.5-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libyaml-0-2",
+      "version": "0.2.5-2",
+      "architecture": "arm64",
+      "link": "pool/main/liby/libyaml/libyaml-0-2_0.2.5-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libyuv0",
+      "version": "0.0.1904.20250204-1",
+      "architecture": "amd64",
+      "link": "pool/main/liby/libyuv/libyuv0_0.0.1904.20250204-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libyuv0",
+      "version": "0.0.1904.20250204-1",
+      "architecture": "arm64",
+      "link": "pool/main/liby/libyuv/libyuv0_0.0.1904.20250204-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libz3-4",
+      "version": "4.13.3-1",
+      "architecture": "amd64",
+      "link": "pool/main/z/z3/libz3-4_4.13.3-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libz3-4",
+      "version": "4.13.3-1",
+      "architecture": "arm64",
+      "link": "pool/main/z/z3/libz3-4_4.13.3-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libzip5",
+      "version": "1.11.3-2",
+      "architecture": "amd64",
+      "link": "pool/main/libz/libzip/libzip5_1.11.3-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libzip5",
+      "version": "1.11.3-2",
+      "architecture": "arm64",
+      "link": "pool/main/libz/libzip/libzip5_1.11.3-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libzstd1",
+      "version": "1.5.7+dfsg-1",
+      "architecture": "amd64",
+      "link": "pool/main/libz/libzstd/libzstd1_1.5.7+dfsg-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "libzstd1",
+      "version": "1.5.7+dfsg-1",
+      "architecture": "arm64",
+      "link": "pool/main/libz/libzstd/libzstd1_1.5.7+dfsg-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "linux-libc-dev",
+      "version": "6.12.86-1",
+      "architecture": "all",
+      "link": "pool/main/l/linux/linux-libc-dev_6.12.86-1_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "lldb",
+      "version": "1:19.0-63",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-defaults/lldb_19.0-63_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "lldb",
+      "version": "1:19.0-63",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-defaults/lldb_19.0-63_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "lldb-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-toolchain-19/lldb-19_19.1.7-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "lldb-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-toolchain-19/lldb-19_19.1.7-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "llvm-19-linker-tools",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-toolchain-19/llvm-19-linker-tools_19.1.7-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "llvm-19-linker-tools",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-toolchain-19/llvm-19-linker-tools_19.1.7-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "make",
+      "version": "4.4.1-2",
+      "architecture": "amd64",
+      "link": "pool/main/m/make-dfsg/make_4.4.1-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "make",
+      "version": "4.4.1-2",
+      "architecture": "arm64",
+      "link": "pool/main/m/make-dfsg/make_4.4.1-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "make-guile",
+      "version": "4.4.1-2",
+      "architecture": "amd64",
+      "link": "pool/main/m/make-dfsg/make-guile_4.4.1-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "make-guile",
+      "version": "4.4.1-2",
+      "architecture": "arm64",
+      "link": "pool/main/m/make-dfsg/make-guile_4.4.1-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "media-types",
+      "version": "13.0.0",
+      "architecture": "all",
+      "link": "pool/main/m/media-types/media-types_13.0.0_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "netbase",
+      "version": "6.5",
+      "architecture": "all",
+      "link": "pool/main/n/netbase/netbase_6.5_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "netstandard-targeting-pack-2.1",
+      "version": "2.1.0-1",
+      "architecture": "amd64",
+      "link": "pool/main/n/netstandard-targeting-pack-2.1/netstandard-targeting-pack-2.1_2.1.0-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "ninja-build",
+      "version": "1.12.1-1",
+      "architecture": "amd64",
+      "link": "pool/main/n/ninja-build/ninja-build_1.12.1-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "ninja-build",
+      "version": "1.12.1-1+b1",
+      "architecture": "arm64",
+      "link": "pool/main/n/ninja-build/ninja-build_1.12.1-1+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "oc",
+      "version": "4.19.0",
+      "architecture": "amd64",
+      "link": "artifacts/oc/amd64.tar.gz",
+      "type": "artifact"
+    },
+    {
+      "name": "oc",
+      "version": "4.19.0",
+      "architecture": "arm64",
+      "link": "artifacts/oc/arm64.tar.gz",
+      "type": "artifact"
+    },
+    {
+      "name": "openssl",
+      "version": "3.5.6-1~deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/o/openssl/openssl_3.5.6-1~deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "openssl",
+      "version": "3.5.6-1~deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/o/openssl/openssl_3.5.6-1~deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "openssl-provider-legacy",
+      "version": "3.5.6-1~deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/o/openssl/openssl-provider-legacy_3.5.6-1~deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "openssl-provider-legacy",
+      "version": "3.5.6-1~deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/o/openssl/openssl-provider-legacy_3.5.6-1~deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "patch",
+      "version": "2.8-2",
+      "architecture": "amd64",
+      "link": "pool/main/p/patch/patch_2.8-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "patch",
+      "version": "2.8-2",
+      "architecture": "arm64",
+      "link": "pool/main/p/patch/patch_2.8-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "perl",
+      "version": "5.40.1-6",
+      "architecture": "amd64",
+      "link": "pool/main/p/perl/perl_5.40.1-6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "perl",
+      "version": "5.40.1-6",
+      "architecture": "arm64",
+      "link": "pool/main/p/perl/perl_5.40.1-6_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "perl-base",
+      "version": "5.40.1-6",
+      "architecture": "amd64",
+      "link": "pool/main/p/perl/perl-base_5.40.1-6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "perl-base",
+      "version": "5.40.1-6",
+      "architecture": "arm64",
+      "link": "pool/main/p/perl/perl-base_5.40.1-6_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "perl-modules-5.40",
+      "version": "5.40.1-6",
+      "architecture": "all",
+      "link": "pool/main/p/perl/perl-modules-5.40_5.40.1-6_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php-common",
+      "version": "2:101~+0~20260503.72+debian13~1.gbp7da167",
+      "architecture": "all",
+      "link": "pool/main/p/php-defaults/php-common_101~+0~20260503.72+debian13~1.gbp7da167_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php8.5",
+      "version": "8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6",
+      "architecture": "all",
+      "link": "pool/main/p/php8.5/php8.5_8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php8.5-bcmath",
+      "version": "8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6",
+      "architecture": "amd64",
+      "link": "pool/main/p/php8.5/php8.5-bcmath_8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php8.5-cli",
+      "version": "8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6",
+      "architecture": "amd64",
+      "link": "pool/main/p/php8.5/php8.5-cli_8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php8.5-common",
+      "version": "8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6",
+      "architecture": "amd64",
+      "link": "pool/main/p/php8.5/php8.5-common_8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php8.5-curl",
+      "version": "8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6",
+      "architecture": "amd64",
+      "link": "pool/main/p/php8.5/php8.5-curl_8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php8.5-gd",
+      "version": "8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6",
+      "architecture": "amd64",
+      "link": "pool/main/p/php8.5/php8.5-gd_8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php8.5-intl",
+      "version": "8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6",
+      "architecture": "amd64",
+      "link": "pool/main/p/php8.5/php8.5-intl_8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php8.5-mbstring",
+      "version": "8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6",
+      "architecture": "amd64",
+      "link": "pool/main/p/php8.5/php8.5-mbstring_8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php8.5-pcov",
+      "version": "1.0.12-2+0~20251124.33+debian13~1.gbp5b3479",
+      "architecture": "amd64",
+      "link": "pool/main/p/php-pcov/php8.5-pcov_1.0.12-2+0~20251124.33+debian13~1.gbp5b3479_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php8.5-pcov",
+      "version": "1.0.12-2+0~20251124.33+debian13~1.gbp5b3479",
+      "architecture": "arm64",
+      "link": "pool/main/p/php-pcov/php8.5-pcov_1.0.12-2+0~20251124.33+debian13~1.gbp5b3479_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php8.5-pgsql",
+      "version": "8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6",
+      "architecture": "amd64",
+      "link": "pool/main/p/php8.5/php8.5-pgsql_8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php8.5-readline",
+      "version": "8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6",
+      "architecture": "amd64",
+      "link": "pool/main/p/php8.5/php8.5-readline_8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php8.5-sqlite3",
+      "version": "8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6",
+      "architecture": "amd64",
+      "link": "pool/main/p/php8.5/php8.5-sqlite3_8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php8.5-xml",
+      "version": "8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6",
+      "architecture": "amd64",
+      "link": "pool/main/p/php8.5/php8.5-xml_8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "php8.5-zip",
+      "version": "8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6",
+      "architecture": "amd64",
+      "link": "pool/main/p/php8.5/php8.5-zip_8.5.6-3+0~20260514.18+debian13~1.gbpe4e1f6_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "procps",
+      "version": "2:4.0.4-9",
+      "architecture": "amd64",
+      "link": "pool/main/p/procps/procps_4.0.4-9_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "procps",
+      "version": "2:4.0.4-9",
+      "architecture": "arm64",
+      "link": "pool/main/p/procps/procps_4.0.4-9_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "psmisc",
+      "version": "23.7-2",
+      "architecture": "amd64",
+      "link": "pool/main/p/psmisc/psmisc_23.7-2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "psmisc",
+      "version": "23.7-2",
+      "architecture": "arm64",
+      "link": "pool/main/p/psmisc/psmisc_23.7-2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python-apt-common",
+      "version": "3.0.0",
+      "architecture": "all",
+      "link": "pool/main/p/python-apt/python-apt-common_3.0.0_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3",
+      "version": "3.13.5-1",
+      "architecture": "amd64",
+      "link": "pool/main/p/python3-defaults/python3_3.13.5-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3",
+      "version": "3.13.5-1",
+      "architecture": "arm64",
+      "link": "pool/main/p/python3-defaults/python3_3.13.5-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-apt",
+      "version": "3.0.0",
+      "architecture": "amd64",
+      "link": "pool/main/p/python-apt/python3-apt_3.0.0_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-apt",
+      "version": "3.0.0",
+      "architecture": "arm64",
+      "link": "pool/main/p/python-apt/python3-apt_3.0.0_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-dev",
+      "version": "3.13.5-1",
+      "architecture": "amd64",
+      "link": "pool/main/p/python3-defaults/python3-dev_3.13.5-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-dev",
+      "version": "3.13.5-1",
+      "architecture": "arm64",
+      "link": "pool/main/p/python3-defaults/python3-dev_3.13.5-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-lldb-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "amd64",
+      "link": "pool/main/l/llvm-toolchain-19/python3-lldb-19_19.1.7-3+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-lldb-19",
+      "version": "1:19.1.7-3+b1",
+      "architecture": "arm64",
+      "link": "pool/main/l/llvm-toolchain-19/python3-lldb-19_19.1.7-3+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-minimal",
+      "version": "3.13.5-1",
+      "architecture": "amd64",
+      "link": "pool/main/p/python3-defaults/python3-minimal_3.13.5-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-minimal",
+      "version": "3.13.5-1",
+      "architecture": "arm64",
+      "link": "pool/main/p/python3-defaults/python3-minimal_3.13.5-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-packaging",
+      "version": "25.0-1",
+      "architecture": "all",
+      "link": "pool/main/p/python-packaging/python3-packaging_25.0-1_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-pip",
+      "version": "25.1.1+dfsg-1",
+      "architecture": "all",
+      "link": "pool/main/p/python-pip/python3-pip_25.1.1+dfsg-1_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-pip-whl",
+      "version": "25.1.1+dfsg-1",
+      "architecture": "all",
+      "link": "pool/main/p/python-pip/python3-pip-whl_25.1.1+dfsg-1_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-setuptools-whl",
+      "version": "78.1.1-0.1",
+      "architecture": "all",
+      "link": "pool/main/s/setuptools/python3-setuptools-whl_78.1.1-0.1_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-venv",
+      "version": "3.13.5-1",
+      "architecture": "amd64",
+      "link": "pool/main/p/python3-defaults/python3-venv_3.13.5-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-venv",
+      "version": "3.13.5-1",
+      "architecture": "arm64",
+      "link": "pool/main/p/python3-defaults/python3-venv_3.13.5-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-wheel",
+      "version": "0.46.1-2",
+      "architecture": "all",
+      "link": "pool/main/w/wheel/python3-wheel_0.46.1-2_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-yaml",
+      "version": "6.0.2-1+b2",
+      "architecture": "amd64",
+      "link": "pool/main/p/pyyaml/python3-yaml_6.0.2-1+b2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3-yaml",
+      "version": "6.0.2-1+b2",
+      "architecture": "arm64",
+      "link": "pool/main/p/pyyaml/python3-yaml_6.0.2-1+b2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3.13",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "amd64",
+      "link": "pool/main/p/python3.13/python3.13_3.13.5-2+deb13u2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3.13",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "arm64",
+      "link": "pool/main/p/python3.13/python3.13_3.13.5-2+deb13u2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3.13-dev",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "amd64",
+      "link": "pool/main/p/python3.13/python3.13-dev_3.13.5-2+deb13u2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3.13-dev",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "arm64",
+      "link": "pool/main/p/python3.13/python3.13-dev_3.13.5-2+deb13u2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3.13-minimal",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "amd64",
+      "link": "pool/main/p/python3.13/python3.13-minimal_3.13.5-2+deb13u2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3.13-minimal",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "arm64",
+      "link": "pool/main/p/python3.13/python3.13-minimal_3.13.5-2+deb13u2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3.13-venv",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "amd64",
+      "link": "pool/main/p/python3.13/python3.13-venv_3.13.5-2+deb13u2_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "python3.13-venv",
+      "version": "3.13.5-2+deb13u2",
+      "architecture": "arm64",
+      "link": "pool/main/p/python3.13/python3.13-venv_3.13.5-2+deb13u2_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "rclone",
+      "version": "1.60.1+dfsg-4",
+      "architecture": "amd64",
+      "link": "pool/main/r/rclone/rclone_1.60.1+dfsg-4_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "rclone",
+      "version": "1.60.1+dfsg-4",
+      "architecture": "arm64",
+      "link": "pool/main/r/rclone/rclone_1.60.1+dfsg-4_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "readline-common",
+      "version": "8.2-6",
+      "architecture": "all",
+      "link": "pool/main/r/readline/readline-common_8.2-6_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "restic",
+      "version": "0.18.0-1+b4",
+      "architecture": "amd64",
+      "link": "pool/main/r/restic/restic_0.18.0-1+b4_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "restic",
+      "version": "0.18.0-1+b4",
+      "architecture": "arm64",
+      "link": "pool/main/r/restic/restic_0.18.0-1+b4_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "rpcsvc-proto",
+      "version": "1.4.3-1",
+      "architecture": "amd64",
+      "link": "pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.3-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "rpcsvc-proto",
+      "version": "1.4.3-1+b1",
+      "architecture": "arm64",
+      "link": "pool/main/r/rpcsvc-proto/rpcsvc-proto_1.4.3-1+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "sensible-utils",
+      "version": "0.0.25",
+      "architecture": "all",
+      "link": "pool/main/s/sensible-utils/sensible-utils_0.0.25_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "sops",
+      "version": "3.11.0",
+      "architecture": "amd64",
+      "link": "artifacts/sops/sops/amd64",
+      "type": "artifact"
+    },
+    {
+      "name": "sops",
+      "version": "3.11.0",
+      "architecture": "arm64",
+      "link": "artifacts/sops/sops/arm64",
+      "type": "artifact"
+    },
+    {
+      "name": "talos",
+      "version": "1.12.4",
+      "architecture": "amd64",
+      "link": "artifacts/talos/talosctl/amd64",
+      "type": "artifact"
+    },
+    {
+      "name": "talos",
+      "version": "1.12.4",
+      "architecture": "arm64",
+      "link": "artifacts/talos/talosctl/arm64",
+      "type": "artifact"
+    },
+    {
+      "name": "tar",
+      "version": "1.35+dfsg-3.1",
+      "architecture": "amd64",
+      "link": "pool/main/t/tar/tar_1.35+dfsg-3.1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "tar",
+      "version": "1.35+dfsg-3.1",
+      "architecture": "arm64",
+      "link": "pool/main/t/tar/tar_1.35+dfsg-3.1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "terraform",
+      "version": "1.15.4-1",
+      "architecture": "amd64",
+      "link": "pool/main/t/terraform/terraform_1.15.4-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "terraform",
+      "version": "1.15.4-1",
+      "architecture": "arm64",
+      "link": "pool/main/t/terraform/terraform_1.15.4-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "tshark",
+      "version": "4.4.15-0+deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/w/wireshark/tshark_4.4.15-0+deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "tshark",
+      "version": "4.4.15-0+deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/w/wireshark/tshark_4.4.15-0+deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "tzdata",
+      "version": "2026b-0+deb13u1",
+      "architecture": "all",
+      "link": "pool/main/t/tzdata/tzdata_2026b-0+deb13u1_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "ucf",
+      "version": "3.0052",
+      "architecture": "all",
+      "link": "pool/main/u/ucf/ucf_3.0052_all.deb",
+      "type": "apt"
+    },
+    {
+      "name": "wireshark-common",
+      "version": "4.4.15-0+deb13u1",
+      "architecture": "amd64",
+      "link": "pool/main/w/wireshark/wireshark-common_4.4.15-0+deb13u1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "wireshark-common",
+      "version": "4.4.15-0+deb13u1",
+      "architecture": "arm64",
+      "link": "pool/main/w/wireshark/wireshark-common_4.4.15-0+deb13u1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "xz-utils",
+      "version": "5.8.1-1",
+      "architecture": "amd64",
+      "link": "pool/main/x/xz-utils/xz-utils_5.8.1-1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "xz-utils",
+      "version": "5.8.1-1",
+      "architecture": "arm64",
+      "link": "pool/main/x/xz-utils/xz-utils_5.8.1-1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "zlib1g",
+      "version": "1:1.3.dfsg+really1.3.1-1+b1",
+      "architecture": "amd64",
+      "link": "pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "zlib1g",
+      "version": "1:1.3.dfsg+really1.3.1-1+b1",
+      "architecture": "arm64",
+      "link": "pool/main/z/zlib/zlib1g_1.3.dfsg+really1.3.1-1+b1_arm64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "zlib1g-dev",
+      "version": "1:1.3.dfsg+really1.3.1-1+b1",
+      "architecture": "amd64",
+      "link": "pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1+b1_amd64.deb",
+      "type": "apt"
+    },
+    {
+      "name": "zlib1g-dev",
+      "version": "1:1.3.dfsg+really1.3.1-1+b1",
+      "architecture": "arm64",
+      "link": "pool/main/z/zlib/zlib1g-dev_1.3.dfsg+really1.3.1-1+b1_arm64.deb",
+      "type": "apt"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- New distribution lane: `shared/ws-feature-store/manifest.json` → `ws-docs:.vitepress/data/fs-manifest.json` (rename at distribute via `path:` field).
- Seed payload committed (593-entry manifest extracted from `ghcr.io/kloudkit/ws-feature-store:latest`).
- First non-`shared/workspace/*` upstream origin; sync composite was already caller-agnostic.

Bundled with a cosmetic `distribute.yaml` change adding job-name labels for clearer CI UI.

## Story

Part of `ws-bmad` story `2026-q2.30 — feature-store manifest publish`.

After merge, the distribute workflow will fire and open a sync PR against `ws-docs` carrying `.vitepress/data/fs-manifest.json`. The `ws-docs` consumer (partial generator + `editor/features.md` collapsible) is in `feature/fs-manifest-partial`.

## Test plan

- [ ] CI lint passes
- [ ] On merge: distribute workflow runs and opens a sync PR in `ws-docs` carrying the manifest as `fs-manifest.json`