### PR TITLE
🐛 Trigger distribute on inbound sync

### DIFF
--- a/.github/actions/sync/action.yaml
+++ b/.github/actions/sync/action.yaml
@@ -44,16 +44,29 @@ runs:
         done <<< "${{ inputs.files }}"
 
     - name: 📤 Push to ws-meta
+      id: push
       shell: bash
       run: |
         cd _ws-meta
         git add shared/
-        git diff --cached --quiet && echo "No changes" && exit 0
+        if git diff --cached --quiet; then
+          echo "No changes"
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
         git config user.name "kloud-bot"
         git config user.email "ws@kloud.email"
         git commit -m "${{ inputs.commit-message }} [skip ci]"
         git pull --rebase
         git push
+        echo "changed=true" >> "$GITHUB_OUTPUT"
+
+    - name: 🚀 Trigger distribution
+      if: steps.push.outputs.changed == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: gh workflow run distribute.yaml --repo kloudkit/ws-meta --ref main
 
     - name: 🧹 Cleanup
       if: always()

--- a/.github/workflows/distribute.yaml
+++ b/.github/workflows/distribute.yaml
@@ -26,7 +26,11 @@ jobs:
       - name: 📋 Resolve targets
         id: matrix
         run: |
-          FILES=$(git diff --name-only HEAD~1 HEAD -- shared/)
+          if [ "${{ github.event_name }}" = "push" ]; then
+            FILES=$(git diff --name-only HEAD~1 HEAD -- shared/)
+          else
+            FILES=$(yq -r 'keys[]' shared/distribution.yaml)
+          fi
           [ -z "$FILES" ] && echo "targets=[]" >> "$GITHUB_OUTPUT" && exit 0
           scripts/distribute.sh "$FILES"
 


### PR DESCRIPTION
## Problem

Shared-file fan-out (`workspace → ws-meta → ws-docs/ws-helm`) was silently broken. The inbound sync action commits with `[skip ci]`, which also suppressed the `push`-triggered `distribute.yaml` — so downstream repos never received updates. ws-docs' build is currently red because `env.reference.yaml` (with `override_restrictions`) reached ws-meta but was never distributed.

## Fix

- `actions/sync`: emit a `changed` output and explicitly `gh workflow run distribute.yaml` after a successful push. `[skip ci]` is kept so ws-meta's human CI stays quiet; we just stop relying on the suppressed `push` event.
- `distribute.yaml`: on `workflow_dispatch`/non-push, resolve **all** declared shared files instead of a single-commit `HEAD~1 HEAD` diff — fixing the latent backlog bug and making the run self-healing.

Backward-compatible: no input changes, so every caller repo gets fan-out restored automatically.