### PR TITLE
🚀 Mirror workspace releases as public GitHub Releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,59 @@
+---
+name: 🚀 Mirror release
+
+on:
+  workflow_run:
+    workflows:
+      - 📦 Distribute shared files
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: 🏷️ Cut release from changelog
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: 📥 Checkout ws-meta
+        uses: actions/checkout@v6
+
+      - name: 🚀 Cut release if the top version has none
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          changelog="shared/workspace/CHANGELOG.md"
+
+          if [ ! -f "${changelog}" ]; then
+            echo "No ${changelog} yet — nothing to release."
+            exit 0
+          fi
+
+          ver=$(grep -oP '^## \[\K[0-9][0-9.]*' "${changelog}" | head -1)
+
+          if [ -z "${ver}" ]; then
+            echo "No version section found in ${changelog} — skipping."
+            exit 0
+          fi
+
+          if gh release view "v${ver}" -R kloudkit/ws-meta >/dev/null 2>&1; then
+            echo "Release v${ver} already exists — no-op."
+            exit 0
+          fi
+
+          awk '/^## \[/{c++} c==1' "${changelog}" | tail -n +2 > notes.md
+
+          gh release create "v${ver}" \
+            -R kloudkit/ws-meta \
+            --title "v${ver}" \
+            --notes-file notes.md

--- a/shared/distribution.yaml
+++ b/shared/distribution.yaml
@@ -18,6 +18,10 @@ shared/workspace/fonts.yaml:
   - repo: ws-docs
     path: .vitepress/data/fonts.yaml
 
+shared/workspace/CHANGELOG.md:
+  - repo: ws-docs
+    path: .vitepress/data/CHANGELOG.md
+
 shared/ws-feature-store/manifest.json:
   - repo: ws-docs
     path: .vitepress/data/fs-manifest.json


### PR DESCRIPTION
Part 2/3 of **2026-q2-50 public-release-surface** (ws-meta leg). Depends on the workspace PR (which starts `CHANGELOG.md` flowing to `shared/workspace/`).

ws-meta (the public hub) owns both public outputs from the synced changelog.

## Changes
- **`shared/distribution.yaml`** — route `shared/workspace/CHANGELOG.md` → ws-docs `.vitepress/data/CHANGELOG.md` (PR mode, the default — same mechanism as env.reference/dependencies/extensions/fonts).
- **`.github/workflows/release.yaml`** (new) — cut a public GitHub Release from the changelog's top version section.

## release.yaml design
- **Trigger:** `workflow_run` after `📦 Distribute shared files` (+ `workflow_dispatch`). Not `push:` — the inbound sync commits `[skip ci]` and dispatches distribute via `gh workflow run`, so a push trigger would never fire.
- **Idempotent:** `gh release view v$ver || gh release create v$ver` — a release is cut exactly when the top changelog version has none. Re-runs (it fires on *every* distribute, from any origin) are harmless no-ops.
- **Top-version-only, no backfill:** first mirror release is `v0.4.0`; seeded v0.2.0/v0.3.0 sections are never released.
- **Own `GITHUB_TOKEN`** (`contents: write`) — it releases in its *own* repo, so no PAT. ws-meta stays unversioned; the created `vX.Y.Z` tag triggers no ws-meta workflow.
- Guards: skips cleanly if `CHANGELOG.md` is absent (pre-first-sync) or has no version section.

Version/notes extraction verified against the live `workspace/CHANGELOG.md` (`ver=0.4.0`; notes = top block minus its `## [..]` header).