### PR TITLE
🔧 Route the ws-cli command manifest to ws-docs

### DIFF
--- a/shared/distribution.yaml
+++ b/shared/distribution.yaml
@@ -25,3 +25,7 @@ shared/workspace/CHANGELOG.md:
 shared/ws-feature-store/manifest.json:
   - repo: ws-docs
     path: .vitepress/data/fs-manifest.json
+
+shared/ws-cli/commands.yaml:
+  - repo: ws-docs
+    path: .vitepress/data/commands.yaml


### PR DESCRIPTION
Adds the distribution route for `shared/ws-cli/commands.yaml` → `ws-docs/.vitepress/data/commands.yaml`. The manifest is already synced into ws-meta by ws-cli's new origin workflow; this makes it fan out to ws-docs like the other shared manifests. ws-docs generator + page land in a paired PR.